### PR TITLE
Add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+
+# For anything not explicitly taken by someone else:
+* @honeycombio/integrations-team


### PR DESCRIPTION
Adds codeowners file to set @honeycombio/integrations-team as default reviewers.