### PR TITLE
Update exporter to be compatible with 0.15b0

### DIFF
--- a/opentelemetry/ext/honeycomb/__init__.py
+++ b/opentelemetry/ext/honeycomb/__init__.py
@@ -27,11 +27,7 @@ from requests import Session
 
 import opentelemetry.trace as trace_api
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
-
-try:
-    from opentelemetry.trace.status import StatusCode
-except ImportError:
-    from opentelemetry.trace.status import StatusCanonicalCode as StatusCode
+from opentelemetry.trace.status import StatusCode
 
 VERSION = '0.6b0'
 USER_AGENT_ADDITION = 'opentelemetry-exporter-python/%s' % VERSION
@@ -88,7 +84,7 @@ class HoneycombSpanExporter(SpanExporter):
 def _translate_to_hny(spans):
     hny_data = []
     for span in spans:
-        ctx = span.get_context()
+        ctx = span.get_span_context()
         trace_id = ctx.trace_id
         span_id = ctx.span_id
         duration_ns = span.end_time - span.start_time
@@ -98,19 +94,19 @@ def _translate_to_hny(spans):
             'name': span.name,
             'start_time': datetime.datetime.utcfromtimestamp(span.start_time / float(1e9)),
             'duration_ms': duration_ns / float(1e6),  # nanoseconds to ms
-            'response.status_code': span.status.canonical_code.value,
+            'response.status_code': span.status.status_code.value,
             'status.message': span.status.description,
             'span.kind': span.kind.name,  # meta.span_type?
         }
         if isinstance(span.parent, trace_api.Span):
-            d['trace.parent_id'] = trace_api.format_span_id(span.parent.get_context().span_id)[2:]
+            d['trace.parent_id'] = trace_api.format_span_id(span.parent.get_span_context().span_id)[2:]
         elif isinstance(span.parent, trace_api.SpanContext):
             d['trace.parent_id'] = trace_api.format_span_id(span.parent.span_id)[2:]
         # TODO: use sampling_decision attributes for sample rate.
         d.update(span.attributes)
 
         # Ensure that if Status.Code is not OK, that we set the 'error' tag on the Jaeger span.
-        if span.status.canonical_code is not StatusCode.OK:
+        if span.status.status_code is not StatusCode.OK:
             d['error'] = True
         hny_data.extend(_extract_refs_from_span(span))
         hny_data.extend(_extract_logs_from_span(span))
@@ -121,7 +117,7 @@ def _translate_to_hny(spans):
 def _extract_refs_from_span(span):
     refs = []
 
-    ctx = span.get_context()
+    ctx = span.get_span_context()
     trace_id = ctx.trace_id
     p_span_id = ctx.span_id
     for link in span.links:
@@ -143,7 +139,7 @@ def _extract_refs_from_span(span):
 def _extract_logs_from_span(span):
     logs = []
 
-    ctx = span.get_context()
+    ctx = span.get_span_context()
     trace_id = ctx.trace_id
     p_span_id = ctx.span_id
     for event in span.events:

--- a/opentelemetry/ext/honeycomb/__init__.py
+++ b/opentelemetry/ext/honeycomb/__init__.py
@@ -27,7 +27,11 @@ from requests import Session
 
 import opentelemetry.trace as trace_api
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
-from opentelemetry.trace.status import StatusCanonicalCode
+
+try:
+    from opentelemetry.trace.status import StatusCode
+except ImportError:
+    from opentelemetry.trace.status import StatusCanonicalCode as StatusCode
 
 VERSION = '0.6b0'
 USER_AGENT_ADDITION = 'opentelemetry-exporter-python/%s' % VERSION
@@ -106,7 +110,7 @@ def _translate_to_hny(spans):
         d.update(span.attributes)
 
         # Ensure that if Status.Code is not OK, that we set the 'error' tag on the Jaeger span.
-        if span.status.canonical_code is not StatusCanonicalCode.OK:
+        if span.status.canonical_code is not StatusCode.OK:
             d['error'] = True
         hny_data.extend(_extract_refs_from_span(span))
         hny_data.extend(_extract_logs_from_span(span))

--- a/poetry.lock
+++ b/poetry.lock
@@ -25,7 +25,7 @@ wrapt = ">=1.11,<2.0"
 
 [[package]]
 name = "certifi"
-version = "2020.6.20"
+version = "2020.11.8"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -133,7 +133,7 @@ python-versions = "*"
 
 [[package]]
 name = "opentelemetry-api"
-version = "0.14b0"
+version = "0.15b0"
 description = "OpenTelemetry Python API"
 category = "main"
 optional = false
@@ -144,14 +144,14 @@ aiocontextvars = {version = "*", markers = "python_version < \"3.7\" and python_
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "0.14b0"
+version = "0.15b0"
 description = "OpenTelemetry Python SDK"
 category = "main"
 optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
-opentelemetry-api = "0.14b0"
+opentelemetry-api = "0.15b0"
 
 [[package]]
 name = "pycodestyle"
@@ -178,7 +178,7 @@ toml = ">=0.7.1"
 
 [[package]]
 name = "requests"
-version = "2.24.0"
+version = "2.25.0"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
@@ -188,7 +188,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 certifi = ">=2017.4.17"
 chardet = ">=3.0.2,<4"
 idna = ">=2.5,<3"
-urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
+urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
@@ -212,11 +212,11 @@ python-versions = "*"
 
 [[package]]
 name = "toml"
-version = "0.10.1"
+version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "typed-ast"
@@ -261,8 +261,8 @@ astroid = [
     {file = "astroid-2.4.2.tar.gz", hash = "sha256:2f4078c2a41bf377eea06d71c9d2ba4eb8f6b1af2135bec27bbbb7d8f12bb703"},
 ]
 certifi = [
-    {file = "certifi-2020.6.20-py2.py3-none-any.whl", hash = "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"},
-    {file = "certifi-2020.6.20.tar.gz", hash = "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3"},
+    {file = "certifi-2020.11.8-py2.py3-none-any.whl", hash = "sha256:1f422849db327d534e3d0c5f02a263458c3955ec0aae4ff09b95f195c59f4edd"},
+    {file = "certifi-2020.11.8.tar.gz", hash = "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"},
 ]
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
@@ -365,12 +365,12 @@ mccabe = [
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 opentelemetry-api = [
-    {file = "opentelemetry-api-0.14b0.tar.gz", hash = "sha256:1810133c320a6ea0b01455d6aaafa1ba2e0f4a1fc8707af281d355d94dd29ea5"},
-    {file = "opentelemetry_api-0.14b0-py3-none-any.whl", hash = "sha256:85cb4f8e9a7ae253d7c04722d6dfd5a4fd7fa78f07c6a82824f4b76719ed1bfe"},
+    {file = "opentelemetry-api-0.15b0.tar.gz", hash = "sha256:936fb836f47d876a9534939b49094a4d190bba98f3e6474c75f329e301af4c1e"},
+    {file = "opentelemetry_api-0.15b0-py3-none-any.whl", hash = "sha256:eee7da8a40bb9bd5ad557d084f5e2972372035de4b094d660dae309e24d15d10"},
 ]
 opentelemetry-sdk = [
-    {file = "opentelemetry-sdk-0.14b0.tar.gz", hash = "sha256:5b6572dcc21a6718889af78b5ad79b8a0f4609f36f7ab26fc2acaf80d8452ce4"},
-    {file = "opentelemetry_sdk-0.14b0-py3-none-any.whl", hash = "sha256:4370db058765dd91b4b65b92827165461069a22bb598bb0cb6986c96948c8dfc"},
+    {file = "opentelemetry-sdk-0.15b0.tar.gz", hash = "sha256:bbb6fb75d86473b4bb274c6ccb8768b8a9aa37446cbb62683cf8e65be079ac80"},
+    {file = "opentelemetry_sdk-0.15b0-py3-none-any.whl", hash = "sha256:60b1870081d3fbe005c1fee566f06dce118c4ba7c12d7bc480ad1a2b1f8152f3"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.6.0-py2.py3-none-any.whl", hash = "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367"},
@@ -381,8 +381,8 @@ pylint = [
     {file = "pylint-2.6.0.tar.gz", hash = "sha256:bb4a908c9dadbc3aac18860550e870f58e1a02c9f2c204fdf5693d73be061210"},
 ]
 requests = [
-    {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},
-    {file = "requests-2.24.0.tar.gz", hash = "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b"},
+    {file = "requests-2.25.0-py2.py3-none-any.whl", hash = "sha256:e786fa28d8c9154e6a4de5d46a1d921b8749f8b74e28bde23768e5e16eece998"},
+    {file = "requests-2.25.0.tar.gz", hash = "sha256:7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
@@ -393,8 +393,8 @@ statsd = [
     {file = "statsd-3.3.0.tar.gz", hash = "sha256:e3e6db4c246f7c59003e51c9720a51a7f39a396541cb9b147ff4b14d15b5dd1f"},
 ]
 toml = [
-    {file = "toml-0.10.1-py2.py3-none-any.whl", hash = "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"},
-    {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 typed-ast = [
     {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.5"
-opentelemetry-api = ">=0.14b0"
-opentelemetry-sdk = ">=0.14b0"
+opentelemetry-api = ">=0.15b0"
+opentelemetry-sdk = ">=0.15b0"
 libhoney = ">=1.9.0"
 [tool.poetry.dev-dependencies]
 pylint = "^2.6.0"


### PR DESCRIPTION
Fixes #9 and #10 

* `Span.get_context()` is now `Span.get_span_context()`
* `StatusCanonicalCode` has been renamed to `StatusCode`