### PR TITLE
[pipi] set package name correctly

### DIFF
--- a/opentelemetry/ext/honeycomb/__init__.py
+++ b/opentelemetry/ext/honeycomb/__init__.py
@@ -29,7 +29,7 @@ import opentelemetry.trace as trace_api
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 from opentelemetry.trace.status import StatusCode
 
-VERSION = '0.15b0'
+VERSION = '0.15b1'
 USER_AGENT_ADDITION = 'opentelemetry-exporter-python/%s' % VERSION
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
-name = "opentelemetry-honeycomb"
-version = "0.15b0"
+name = "opentelemetry-ext-honeycomb"
+version = "0.15b1"
 description = "OpenTelemetry plugins for Honeycomb"
 authors = ["Honeycomb Authors <solutions@honeycomb.io>"]
 license = "Apache-2.0"


### PR DESCRIPTION
We accidentally published to https://pypi.org/project/opentelemetry-honeycomb/ instead of https://pypi.org/project/opentelemetry-ext-honeycomb/