### PR TITLE
Use public CircleCI context for build secrets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,40 +164,47 @@ workflows:
                 - main
     jobs:
       - setup_trace:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
       - watch:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
           requires:
             - setup_trace
       - test_python3-5:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
           requires:
             - setup_trace
       - test_python3-6:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
           requires:
             - setup_trace
       - test_python3-7:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
           requires:
             - setup_trace
       - test_python3-8:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
           requires:
             - setup_trace
       - build:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
@@ -210,40 +217,47 @@ workflows:
   build_opentelemetry:
     jobs:
       - setup_trace:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
       - watch:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
           requires:
             - setup_trace
       - test_python3-5:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
           requires:
             - setup_trace
       - test_python3-6:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
           requires:
             - setup_trace
       - test_python3-7:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
           requires:
             - setup_trace
       - test_python3-8:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
           requires:
             - setup_trace
       - build:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
@@ -253,7 +267,7 @@ workflows:
             - test_python3-7
             - test_python3-8
       - publish_github:
-          context: Honeycomb Secrets
+          context: Honeycomb Secrets for Public Repos
           requires:
             - build
           filters:
@@ -262,7 +276,7 @@ workflows:
             branches:
               ignore: /.*/
       - publish_pypi:
-          context: Honeycomb Secrets
+          context: Honeycomb Secrets for Public Repos
           requires:
             - build
           filters:


### PR DESCRIPTION
* public context is identical to the old context, with the exception of Github token,
which only has access to public repos
* (secrets are still internal to Honeycombers)
* currently buildevents secrets are pulled from the project env variables in CircleCI
* using a shared context consolidates secrets storage, makes for easier secret updates
* secret values are unchanged from what's currently in the project env variables

Each job uses the [buildevents orb](https://github.com/honeycombio/buildevents-orb/), which requires the buildevents env variables. Adding the context in each job is equivalent to what happens today with project env variables. 

### Considerations

* Removing buildevents -- it sounds that in the past having buildevents caused forked PRs not to build. This is not ideal, but I think this is an issues with buildevents/buildevents orb. It should allow the build to run, even if there's no secrets.