### PR TITLE
Fix failing nightly scheduled workflow in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,22 +157,12 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "7 18 * * *"
+          cron: "51 19 * * *"
           filters:
             branches:
               only:
                 - vera.test-cci
     jobs:
-      - setup_trace:
-          filters:
-            tags:
-              only: /.*/
-      - watch:
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - setup_trace
       - test_python3-5:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "1 11 * * *"
+          cron: "7 18 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,11 +151,11 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "7 20 * * *"
+          cron: "0 0 * * *"
           filters:
             branches:
               only:
-                - vera.test-cci
+                - main
     jobs:
       - test_python3-5
       - test_python3-6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,11 +214,15 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: /pull\/.*/
       - watch:
           context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: /pull\/.*/
           requires:
             - setup_trace
       - test_python3-5:
@@ -226,6 +230,8 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: /pull\/.*/
           requires:
             - setup_trace
       - test_python3-6:
@@ -233,6 +239,8 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: /pull\/.*/
           requires:
             - setup_trace
       - test_python3-7:
@@ -240,6 +248,8 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: /pull\/.*/
           requires:
             - setup_trace
       - test_python3-8:
@@ -247,6 +257,8 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: /pull\/.*/
           requires:
             - setup_trace
       - build:
@@ -254,6 +266,8 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore: /pull\/.*/
           requires:
             - test_python3-5
             - test_python3-6
@@ -277,3 +291,31 @@ workflows:
               only: /v[0-9].*/
             branches:
               ignore: /.*/
+
+  build_opentelemetry_forked:
+    jobs:
+      - test_python3-5:
+          filters:
+            branches:
+              only: /pull\/.*/
+      - test_python3-6:
+          filters:
+            branches:
+              only: /pull\/.*/
+      - test_python3-7:
+          filters:
+            branches:
+              only: /pull\/.*/
+      - test_python3-8:
+          filters:
+            branches:
+              only: /pull\/.*/
+      - build:
+          filters:
+            branches:
+              only: /pull\/.*/
+          requires:
+            - test_python3-5
+            - test_python3-6
+            - test_python3-7
+            - test_python3-8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,47 +164,40 @@ workflows:
                 - main
     jobs:
       - setup_trace:
-          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
       - watch:
-          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
           requires:
             - setup_trace
       - test_python3-5:
-          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
           requires:
             - setup_trace
       - test_python3-6:
-          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
           requires:
             - setup_trace
       - test_python3-7:
-          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
           requires:
             - setup_trace
       - test_python3-8:
-          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
           requires:
             - setup_trace
       - build:
-          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "*/5 * * * *"
+          cron: "1 11 * * *"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,12 +94,6 @@ commands:
           bename: poetry_publish
           becommand: poetry publish --build -u honeycomb -p ${PYPI_PASSWORD}
 
-# required as all of the jobs need to have a tag filter for some reason
-tag_filters: &tag_filters
-  filters:
-    tags:
-      only: /.*/
-
 jobs:
   setup_trace:
     executor: python3-8
@@ -157,32 +151,45 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "51 19 * * *"
+          cron: "7 20 * * *"
           filters:
             branches:
               only:
                 - vera.test-cci
     jobs:
+      - test_python3-5
+      - test_python3-6
+      - test_python3-7
+      - test_python3-8
+      - build:
+          requires:
+            - test_python3-5
+            - test_python3-6
+            - test_python3-7
+            - test_python3-8
+
+  build_opentelemetry_forked:
+    jobs:
       - test_python3-5:
           filters:
-            tags:
-              only: /.*/
+            branches:
+              only: /pull\/.*/
       - test_python3-6:
           filters:
-            tags:
-              only: /.*/
+            branches:
+              only: /pull\/.*/
       - test_python3-7:
           filters:
-            tags:
-              only: /.*/
+            branches:
+              only: /pull\/.*/
       - test_python3-8:
           filters:
-            tags:
-              only: /.*/
+            branches:
+              only: /pull\/.*/
       - build:
           filters:
-            tags:
-              only: /.*/
+            branches:
+              only: /pull\/.*/
           requires:
             - test_python3-5
             - test_python3-6
@@ -273,31 +280,3 @@ workflows:
               only: /v[0-9].*/
             branches:
               ignore: /.*/
-
-  build_opentelemetry_forked:
-    jobs:
-      - test_python3-5:
-          filters:
-            branches:
-              only: /pull\/.*/
-      - test_python3-6:
-          filters:
-            branches:
-              only: /pull\/.*/
-      - test_python3-7:
-          filters:
-            branches:
-              only: /pull\/.*/
-      - test_python3-8:
-          filters:
-            branches:
-              only: /pull\/.*/
-      - build:
-          filters:
-            branches:
-              only: /pull\/.*/
-          requires:
-            - test_python3-5
-            - test_python3-6
-            - test_python3-7
-            - test_python3-8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,26 +167,18 @@ workflows:
           filters:
             tags:
               only: /.*/
-          requires:
-            - setup_trace
       - test_python3-6:
           filters:
             tags:
               only: /.*/
-          requires:
-            - setup_trace
       - test_python3-7:
           filters:
             tags:
               only: /.*/
-          requires:
-            - setup_trace
       - test_python3-8:
           filters:
             tags:
               only: /.*/
-          requires:
-            - setup_trace
       - build:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,11 +157,11 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "*/5 * * * *"
           filters:
             branches:
               only:
-                - main
+                - vera.test-cci
     jobs:
       - setup_trace:
           filters:


### PR DESCRIPTION
Nightly builds are failing because scheduled workflows don't get access to restricted contexts in [Circle](https://circleci.canny.io/cloud-feature-requests/p/allow-restricted-contexts-within-scheduled-workflows). Context is necessary to access the buildevents secrets.

### Changes
* remove buildevents from the nightly workflow
* add build_opentelemetry_forked workflow without buildevents, so forked PRs can run builds
* exclude forked PRs from the main workflow

### Considerations
* Initial thought was to remove buildevents entirely, since there's a precedent for other OSS repos. This configuration should allow us to keep getting telemetry from the internal builds (except nightly), and allow forked PRs to run checks.