### PR TITLE
Fix CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,11 +151,11 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "5 18 * * *"
+          cron: "0 0 * * *"
           filters:
             branches:
               only:
-                - vera.fix-build
+                - main
     jobs:
       - setup_trace
       - test_python3-5:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,45 +151,26 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "55 17 * * *"
+          cron: "5 18 * * *"
           filters:
             branches:
               only:
                 - vera.fix-build
     jobs:
-      - test_python3-5
-      - test_python3-6
-      - test_python3-7
-      - test_python3-8
-      - build:
-          requires:
-            - test_python3-5
-            - test_python3-6
-            - test_python3-7
-            - test_python3-8
-
-  build_opentelemetry_forked:
-    jobs:
+      - setup_trace
       - test_python3-5:
-          filters:
-            branches:
-              only: /pull\/.*/
+          requires:
+            - setup_trace
       - test_python3-6:
-          filters:
-            branches:
-              only: /pull\/.*/
+          requires:
+            - setup_trace
       - test_python3-7:
-          filters:
-            branches:
-              only: /pull\/.*/
+          requires:
+            - setup_trace
       - test_python3-8:
-          filters:
-            branches:
-              only: /pull\/.*/
+          requires:
+            - setup_trace
       - build:
-          filters:
-            branches:
-              only: /pull\/.*/
           requires:
             - test_python3-5
             - test_python3-6
@@ -199,12 +180,9 @@ workflows:
   build_opentelemetry:
     jobs:
       - setup_trace:
-          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
-            branches:
-              ignore: /pull\/.*/
       - watch:
           context: Honeycomb Secrets for Public Repos
           filters:
@@ -215,48 +193,33 @@ workflows:
           requires:
             - setup_trace
       - test_python3-5:
-          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
-            branches:
-              ignore: /pull\/.*/
           requires:
             - setup_trace
       - test_python3-6:
-          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
-            branches:
-              ignore: /pull\/.*/
           requires:
             - setup_trace
       - test_python3-7:
-          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
-            branches:
-              ignore: /pull\/.*/
           requires:
             - setup_trace
       - test_python3-8:
-          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
-            branches:
-              ignore: /pull\/.*/
           requires:
             - setup_trace
       - build:
-          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
-            branches:
-              ignore: /pull\/.*/
           requires:
             - test_python3-5
             - test_python3-6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  buildevents: honeycombio/buildevents@0.2.6
+  buildevents: honeycombio/buildevents@0.2.7
 
 executors:
   python3-5:
@@ -151,11 +151,11 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "55 17 * * *"
           filters:
             branches:
               only:
-                - main
+                - vera.fix-build
     jobs:
       - test_python3-5
       - test_python3-6


### PR DESCRIPTION
Forked [PR failed](https://app.circleci.com/pipelines/github/honeycombio/opentelemetry-exporter-python/158/workflows/19f052e4-7bcf-4413-a53c-afd86923e003), because turns out you do still need a buildevents executable, even for noop buildevents wrappers. (my earlier test PR went green, because it hit a buildevents-orb cache)

### Changes
* bump buildevents-orb because why not
* add setup_trace to the nightly workflow, so it can download the build events executable and cache it
* collapse forked and main workflows, because there aren't enough differences to warrant the split anymore:
  * the only difference is the the watch step, which needs the secrets to send things over to build events. Exclude that step from forked PR workflows.
* remove secrets from steps that don't need them

![tryagain](https://user-images.githubusercontent.com/6738917/103421630-9a222180-4b5a-11eb-9515-30abd89c0e11.gif)
