### PR TITLE
Exclude start_time (datetime) from event fields

### DIFF
--- a/opentelemetry/ext/honeycomb/__init__.py
+++ b/opentelemetry/ext/honeycomb/__init__.py
@@ -75,9 +75,10 @@ class HoneycombSpanExporter(SpanExporter):
     def export(self, spans):
         hny_data = _translate_to_hny(spans)
         for d in hny_data:
-            e = libhoney.Event(data=d, client=self.client)
-            e.created_at = d['start_time']
+            start_time = d['start_time']
             del d['start_time']
+            e = libhoney.Event(data=d, client=self.client)
+            e.created_at = start_time
             e.send()
         return SpanExportResult.SUCCESS
 


### PR DESCRIPTION
With libhoney==1.1.0, as required by the lock file, there is a
serialization issue where it tries to serialize the start_time field of
the event as JSON; however, the value is a Python datetime.datetime,
which is not serializable. This results in a silent error when using the
exporter unless turning on debug logging, which shows something to the
effect of:
```
enqueuing response = {'status_code': 0, 'body': '',
  'error': TypeError('datetime.datetime(2021, 6, 10, 0, 21, 51, 573594) is not JSON serializable'),
  'duration': 0.5705356597900391, 'metadata': None}
```

While the conversion from OTLP start_time to the Honeycomb-compliant
Event created_at works, the code left the start_time field as part of
the event, leading to the aforementioned serialization error. Although
there is a deletion, it only deletes it from the temporary dictionary,
but not the created event's fields. As a result, we need to delete the
start_time from the data dictionary before creating the event.